### PR TITLE
3.0.1: piped --json truncation, !include diagnostics, view/skill install targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,62 @@ All notable changes to `aact` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.0.1 — 2026-09-06
+
+> Patch release. The `--json` envelope now survives a pipe, a missing
+> `!include` names itself, and `aact view` / `aact skill install` point at
+> targets that exist. It also carries the post-GA review fixes that were
+> merged upstream after v3.0.0 — including one breaking change to the
+> `FormatSyntax` plugin surface, kept in a patch because it shipped with
+> those fixes.
+
+### Fixed
+
+- **`--json` output is no longer truncated at 65536 bytes when stdout is a
+  pipe.** The CLI called `process.exit` immediately after an async stdout
+  write, so whatever the pipe had not drained was discarded: any consumer
+  reading the envelope from a subprocess got invalid JSON once the payload
+  passed the pipe buffer — a ~40-element model is already past it. The exit
+  path now waits for both standard streams to reach the OS. Redirecting to a
+  file or writing to a TTY was never affected, which is how this survived to
+  GA.
+- **A missing local `!include` names the include, not the entry point.** The
+  loaders' `ENOENT` reached the CLI indistinguishable from a missing source
+  file, so the diagnostic read `Architecture file not found: <entry point>` —
+  the one file that was fine. Both the C4-PlantUML and the Structurizr DSL
+  loader now report `model.includeNotFound` with the missing path, the file
+  holding the directive, and its line and column; nested chains report the
+  innermost site.
+- **`aact view` opens an authorised URL.** `listhen` opens its own `baseURL`,
+  so the per-session token is passed there instead of being appended after
+  `listen()` returned — the browser no longer lands on an unauthorised bare
+  URL.
+- **`aact view` install hints target the stable channel.** They still told
+  users to install `aact@beta` / `@aact/view@beta` after GA.
+- **`aact skill install` clones a repository that exists.** The default clone
+  target had moved to `Byndyusoft/aact-architect-skill` ahead of the repo
+  transfer, so the documented way for an agent to install the skill failed on
+  a 404. It points back at `ChS23/aact-architect-skill` until the transfer
+  happens.
+- **`aact generate` reports bad output instead of writing it.** Element or
+  boundary names that cannot become a DNS-1123 Kubernetes name, two names
+  that normalise to the same one, absolute or directory-escaping generated
+  paths, and two artefacts claiming one path now surface as
+  `format.invalidGeneratedName`, `format.unsafeOutputPath` and
+  `format.outputPathCollision`.
+
+### Changed
+
+- **BREAKING: `FormatSyntax.containerDecl` takes the Model `Element`**
+  instead of `(name, label, tags)`. Rebuilding a declaration from three
+  positional fields silently dropped description, technology, link and user
+  properties, so an auto-fix that re-declared a container erased model data.
+  Custom rules that call `containerDecl`, and formats that implement it, must
+  pass / accept the element. This is a breaking change in a patch release: it
+  landed with the post-GA review fixes merged upstream, and is documented
+  here rather than renumbered. The JSON contract is untouched —
+  `schemaVersion` stays `1`.
+
 ## v3.0.0 — 2026-06-21
 
 > First stable v3. `schemaVersion: 1` is now frozen as the public contract.

--- a/docs/guides/explore-view.md
+++ b/docs/guides/explore-view.md
@@ -7,12 +7,12 @@
 и циклы целиком.
 
 ```bash
-npx -p aact@beta -p @aact/view@beta aact view
+npx -p aact -p @aact/view aact view
 ```
 
 `aact view` живёт в отдельном пакете `@aact/view` (чтобы CI и `aact check` не
 тянули фронтенд) — отсюда запуск через `npx -p`. Поставите локально
-(`pnpm add -D aact@beta @aact/view@beta`) — тогда просто `npx aact view`.
+(`pnpm add -D aact @aact/view`) — тогда просто `npx aact view`.
 
 ![Workbench в режиме Expand: Billing раскрыт, Orders и Catalog свёрнуты, справа — детали boundary](assets/explore-view/workbench.png)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aact",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "description": "Architecture analysis and compliance tool",
   "keywords": [

--- a/packages/view/package.json
+++ b/packages/view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aact/view",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Local architecture workbench for aact — browser-based live viewer of the normalised C4 Model.",
   "type": "module",
   "license": "GPL-3.0",

--- a/src/cli/commands/diff/index.ts
+++ b/src/cli/commands/diff/index.ts
@@ -241,7 +241,7 @@ export const diff = defineCommand({
         },
       });
       await reporter.emit({ envelope });
-      exitWith(envelope.exitCode);
+      await exitWith(envelope.exitCode);
     } catch (error) {
       const envelope = buildErrorEnvelope({
         command: "diff",
@@ -254,7 +254,7 @@ export const diff = defineCommand({
       // reporter — JsonReporter handles null payload, HumanReporter
       // diverts to renderErrorEnvelope.
       await (reporter as unknown as Reporter).emit({ envelope });
-      exitWith(envelope.exitCode);
+      await exitWith(envelope.exitCode);
     }
   },
 });

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -15,7 +15,11 @@ import { jsonArg } from "../sharedArgs";
 
 const skillName = "aact-architect";
 const markerFileName = ".aact-skill.json";
-const defaultRepo = "https://github.com/Byndyusoft/aact-architect-skill.git";
+// The skill lives in its own repo so it can be updated without a CLI
+// release. Byndyusoft/aact-architect-skill does not exist yet — point at
+// the published one until the skill repo is transferred to the org, or
+// `aact skill install` fails on a 404 clone.
+const defaultRepo = "https://github.com/ChS23/aact-architect-skill.git";
 const defaultRef = "main";
 
 const clientValues = [

--- a/src/cli/commands/view.ts
+++ b/src/cli/commands/view.ts
@@ -66,10 +66,11 @@ const isModuleNotFound = (error: unknown): boolean => {
 
 /**
  * The dist-tag the install hint and prompt target. Tied to the
- * core's release channel — when aact graduates beta, change to
- * `latest` (or drop the qualifier).
+ * core's release channel — `latest` since v3.0.0 GA. Keep the core and
+ * the companion on the same tag: a hint that mixes channels installs
+ * two halves that were never released together.
  */
-const COMPANION_DIST_TAG = "beta";
+const COMPANION_DIST_TAG = "latest";
 const CORE_INSTALL_SPEC = `aact@${COMPANION_DIST_TAG}`;
 const COMPANION_INSTALL_SPEC = `@aact/view@${COMPANION_DIST_TAG}`;
 

--- a/src/cli/loadModel.ts
+++ b/src/cli/loadModel.ts
@@ -1,6 +1,7 @@
 import path from "pathe";
 
 import type { AactConfig } from "../config";
+import { IncludeNotFoundError } from "../formats/_shared/includeError";
 import { loadFormat } from "../formats/registry";
 import type { LoadResult } from "../formats/types";
 import { canLoad } from "../formats/types";
@@ -144,7 +145,38 @@ export const loadModel = async (config: AactConfig): Promise<LoadResult> => {
     return await format.load(resolvedPath, config.source.options);
   } catch (error) {
     if (error instanceof ToolError) throw error;
+    // A missing `!include` is a different repair than a missing entry
+    // point: the file to create is the include target, and the file to
+    // edit is the one holding the directive. Reporting `config.source.path`
+    // for both (which is what a bare ENOENT collapses to) sends the reader
+    // to a file that exists and looks fine.
+    if (error instanceof IncludeNotFoundError) {
+      const { site } = error;
+      throw new ToolError(
+        "model.includeNotFound",
+        `Included file not found: ${site.missingPath}. Referenced as "${site.target}" from ${site.includedFrom}:${site.line}:${site.column}. Create the file or fix the include path.`,
+        {
+          path: site.missingPath,
+          target: site.target,
+          includedFrom: site.includedFrom,
+          line: String(site.line),
+          column: String(site.column),
+        },
+      );
+    }
     if (isFileNotFound(error)) {
+      // Fallback for loaders that pull in extra files without wrapping
+      // their own ENOENT (e.g. Structurizr `!include <directory>`, Compose
+      // `include:`): the errno path still names what actually went
+      // missing, so don't blame the entry point for it.
+      const errnoPath = error.path;
+      if (errnoPath !== undefined && path.resolve(errnoPath) !== resolvedPath) {
+        throw new ToolError(
+          "model.includeNotFound",
+          `Referenced file not found: ${errnoPath}. It was pulled in while loading ${config.source.path}; fix the reference in that source.`,
+          { path: errnoPath, includedFrom: resolvedPath },
+        );
+      }
       throw new ToolError(
         "model.sourceNotFound",
         `Architecture file not found: ${config.source.path}. Update source.path in aact.config.ts or run \`aact init\` to scaffold a starter.`,

--- a/src/cli/output/flush.ts
+++ b/src/cli/output/flush.ts
@@ -1,0 +1,45 @@
+/**
+ * Stdout/stderr flush barrier for the CLI's exit path.
+ *
+ * `process.stdout` is only synchronous when it points at a TTY or a
+ * file. When the CLI is piped (`aact model --json | jq`, `execa`, any
+ * agent reading the envelope from a subprocess) Node writes through an
+ * async libuv stream: `write()` buffers whatever the pipe couldn't take
+ * (64 KB on Linux/macOS) and returns. Calling `process.exit()` right
+ * after that drops the buffered tail on the floor — the consumer gets
+ * the envelope truncated at exactly 65536 bytes, i.e. invalid JSON.
+ *
+ * The barrier: an empty `write` whose callback fires only after every
+ * previously queued chunk has reached the OS (stream callbacks run in
+ * write order). We skip it when nothing is buffered, which keeps the
+ * TTY / file / mocked-stream paths free of extra ticks.
+ */
+const flushStream = (
+  stream: NodeJS.WritableStream | undefined,
+): Promise<void> => {
+  if (stream === undefined || typeof stream.write !== "function") {
+    return Promise.resolve();
+  }
+  const buffered = (stream as Partial<NodeJS.WriteStream>).writableLength;
+  // `undefined` — not a real Writable (tests substitute plain objects).
+  // `0` — everything already handed to the OS, nothing to wait for.
+  if (buffered === undefined || buffered === 0) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    // The callback also fires on error (EPIPE when the reader closed
+    // early, e.g. `aact model --json | head -1`) — resolve either way,
+    // the exit code is decided by the caller, not by the pipe.
+    stream.write("", () => {
+      resolve();
+    });
+  });
+};
+
+/**
+ * Resolves once both standard streams have handed their buffered output
+ * to the OS. Call before `process.exit` so piped consumers see the whole
+ * envelope.
+ */
+export const flushOutput = async (): Promise<void> => {
+  await Promise.all([flushStream(process.stdout), flushStream(process.stderr)]);
+};

--- a/src/cli/output/index.ts
+++ b/src/cli/output/index.ts
@@ -1,5 +1,6 @@
 export type { BuildEnvelopeInput, ErrorEnvelopeInput } from "./envelope";
 export { buildEnvelope, buildErrorEnvelope, errorResult } from "./envelope";
+export { flushOutput } from "./flush";
 export {
   HumanReporter,
   isErrorEnvelope,

--- a/src/cli/output/types.ts
+++ b/src/cli/output/types.ts
@@ -26,6 +26,7 @@ export type DiagnosticKind =
   | "model.loaderWarning"
   // Model load-time errors
   | "model.sourceNotFound"
+  | "model.includeNotFound"
   | "model.parseError"
   | "model.unsupportedLoad"
   // Config layer

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -16,6 +16,7 @@ import type {
 import {
   buildEnvelope,
   buildErrorEnvelope,
+  flushOutput,
   HumanReporter,
   JsonReporter,
   resolveOutputMode,
@@ -108,7 +109,15 @@ const pickReporter = <TData>(
   }
 };
 
-export const exitWith = (code: ExitCode): never => {
+/**
+ * Terminates the process with `code` — after the standard streams have
+ * drained. `process.exit` is immediate and discards whatever stdout still
+ * has buffered, which truncates piped output at the pipe capacity
+ * (64 KB); `flushOutput` is the barrier that makes the envelope survive
+ * `aact model --json | jq` and subprocess consumers. Await it.
+ */
+export const exitWith = async (code: ExitCode): Promise<never> => {
+  await flushOutput();
   // eslint-disable-next-line n/no-process-exit
   process.exit(code);
 };
@@ -165,7 +174,7 @@ export const cliCommand = <TArgs extends ArgsDef, TData>(
           source: null,
         });
         await reporter.emit(result);
-        exitWith(result.envelope.exitCode);
+        await exitWith(result.envelope.exitCode);
       } catch (error) {
         const envelope = buildErrorEnvelope({
           command: opts.name,
@@ -175,7 +184,7 @@ export const cliCommand = <TArgs extends ArgsDef, TData>(
           source: null,
         });
         await reporter.emit({ envelope } as CommandResult<TData>);
-        exitWith(envelope.exitCode);
+        await exitWith(envelope.exitCode);
       }
     },
   });
@@ -241,7 +250,7 @@ export const cliCommandWithConfig = <TArgs extends ArgsDef, TData>(
           source: null,
         });
         await reporter.emit({ envelope } as CommandResult<TData>);
-        exitWith(envelope.exitCode);
+        await exitWith(envelope.exitCode);
         // exitWith is typed `never`, but tests mock process.exit to a no-op
         // — explicit return makes the post-condition (config !== null below)
         // hold in both contexts.
@@ -269,7 +278,7 @@ export const cliCommandWithConfig = <TArgs extends ArgsDef, TData>(
           source: resolvedSource,
         });
         await reporter.emit(result);
-        exitWith(result.envelope.exitCode);
+        await exitWith(result.envelope.exitCode);
       } catch (error) {
         const envelope = buildErrorEnvelope({
           command: opts.name,
@@ -279,7 +288,7 @@ export const cliCommandWithConfig = <TArgs extends ArgsDef, TData>(
           source: resolvedSource,
         });
         await reporter.emit({ envelope } as CommandResult<TData>);
-        exitWith(envelope.exitCode);
+        await exitWith(envelope.exitCode);
       }
     },
   });

--- a/src/formats/_shared/includeError.ts
+++ b/src/formats/_shared/includeError.ts
@@ -1,0 +1,60 @@
+/**
+ * Raised when a local `!include` target doesn't exist on disk.
+ *
+ * Both include-expanding loaders (C4-PlantUML, Structurizr DSL) read the
+ * entry-point file and then recursively read whatever it pulls in. A
+ * plain ENOENT from that recursion is indistinguishable from ENOENT on
+ * the entry point itself, so the CLI used to report "Architecture file
+ * not found: <entry point>" while the entry point was sitting right
+ * there — the one file the user did NOT need to fix. This error carries
+ * the missing target plus the exact directive site that referenced it,
+ * so the diagnostic names the file to create.
+ */
+export interface IncludeSite {
+  /** Absolute path the directive resolved to — the file that's missing. */
+  readonly missingPath: string;
+  /** Target exactly as written in the directive. */
+  readonly target: string;
+  /** Absolute path of the file holding the directive. */
+  readonly includedFrom: string;
+  /** 1-based line of the directive inside `includedFrom`. */
+  readonly line: number;
+  /** 1-based column of the `!` inside `includedFrom`. */
+  readonly column: number;
+}
+
+export class IncludeNotFoundError extends Error {
+  readonly site: IncludeSite;
+
+  constructor(site: IncludeSite, formatLabel: string) {
+    super(
+      `${formatLabel} !include target not found: ${site.missingPath} ` +
+        `(included from ${site.includedFrom}:${site.line}:${site.column} as "${site.target}")`,
+    );
+    this.name = "IncludeNotFoundError";
+    this.site = site;
+  }
+}
+
+const isEnoent = (err: unknown): err is NodeJS.ErrnoException =>
+  typeof err === "object" &&
+  err !== null &&
+  "code" in err &&
+  (err as NodeJS.ErrnoException).code === "ENOENT";
+
+/**
+ * Maps whatever a recursive include expansion threw onto the error to
+ * re-throw: the ENOENT of *this* directive's target becomes an
+ * `IncludeNotFoundError`. Errors from deeper levels (already an
+ * `IncludeNotFoundError`, parse failures, cycles) pass through untouched,
+ * so the innermost site wins.
+ */
+export const toIncludeError = (
+  error: unknown,
+  site: IncludeSite,
+  formatLabel: string,
+): unknown => {
+  if (error instanceof IncludeNotFoundError) return error;
+  if (isEnoent(error)) return new IncludeNotFoundError(site, formatLabel);
+  return error;
+};

--- a/src/formats/plantuml/load.ts
+++ b/src/formats/plantuml/load.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "pathe";
 
 import type { ModelIssue } from "../../model";
+import { toIncludeError } from "../_shared/includeError";
 import type { LoadResult } from "../types";
 import type { PreParseIssue } from "./parser";
 import type { ChevrotainParseError } from "./parser";
@@ -89,7 +90,9 @@ const expandPlantumlIncludes = async (
   try {
     const raw = await fs.readFile(absPath, "utf8");
     const out: string[] = [];
+    let lineNumber = 0;
     for (const line of raw.split(/(?<=\n)/u)) {
+      lineNumber += 1;
       let newline = "";
       if (line.endsWith("\r\n")) newline = "\r\n";
       else if (line.endsWith("\n")) newline = "\n";
@@ -108,11 +111,28 @@ const expandPlantumlIncludes = async (
       }
       if (include.kind === "include_once") includedOnce.add(includePath);
 
-      const expanded = await expandPlantumlIncludes(
-        includePath,
-        stack,
-        includedOnce,
-      );
+      let expanded: string;
+      try {
+        expanded = await expandPlantumlIncludes(
+          includePath,
+          stack,
+          includedOnce,
+        );
+      } catch (error) {
+        // A missing include must name the include, not the entry point
+        // the CLI happened to be pointed at.
+        throw toIncludeError(
+          error,
+          {
+            missingPath: includePath,
+            target: include.target,
+            includedFrom: absPath,
+            line: lineNumber,
+            column: content.length - content.trimStart().length + 1,
+          },
+          "PlantUML",
+        );
+      }
       out.push(expanded);
       if (newline && !expanded.endsWith("\n")) out.push(newline);
     }

--- a/src/formats/structurizr/load.ts
+++ b/src/formats/structurizr/load.ts
@@ -10,6 +10,7 @@ import type {
   Relation,
 } from "../../model";
 import { buildModel, meaningfulTags } from "../../model";
+import { toIncludeError } from "../_shared/includeError";
 import { inferKindFromTechnology } from "../_shared/kindHeuristics";
 import { parseCsvTags } from "../_shared/tags";
 import type { LoadResult } from "../types";
@@ -273,7 +274,9 @@ const expandDslIncludes = async (
   try {
     const text = await fs.readFile(absPath, "utf8");
     const out: string[] = [];
+    let lineNumber = 0;
     for (const line of text.split(/(?<=\n)/u)) {
+      lineNumber += 1;
       let newline = "";
       if (line.endsWith("\r\n")) {
         newline = "\r\n";
@@ -288,7 +291,24 @@ const expandDslIncludes = async (
       }
 
       const includePath = path.resolve(path.dirname(absPath), target);
-      const expanded = await expandDslIncludePath(includePath, stack);
+      let expanded: string;
+      try {
+        expanded = await expandDslIncludePath(includePath, stack);
+      } catch (error) {
+        // Name the missing include, not the workspace file that
+        // references it — the latter is the one file that does exist.
+        throw toIncludeError(
+          error,
+          {
+            missingPath: includePath,
+            target,
+            includedFrom: absPath,
+            line: lineNumber,
+            column: content.length - content.trimStart().length + 1,
+          },
+          "Structurizr DSL",
+        );
+      }
       out.push(expanded);
       if (newline && !expanded.endsWith("\n")) out.push(newline);
     }

--- a/test/cli/loadModel.test.ts
+++ b/test/cli/loadModel.test.ts
@@ -1,6 +1,9 @@
+import path from "pathe";
+
 import { issueToDiagnostic, loadModel } from "../../src/cli/loadModel";
 import { ToolError } from "../../src/cli/output";
 import type { AactConfig } from "../../src/config";
+import { IncludeNotFoundError } from "../../src/formats/_shared/includeError";
 import { loadFormat } from "../../src/formats/registry";
 import type { Format } from "../../src/formats/types";
 import type { ModelIssue } from "../../src/model";
@@ -76,6 +79,68 @@ describe("loadModel", () => {
     await expect(loadModel(structurizrConfig)).rejects.toMatchObject({
       name: "ToolError",
       kind: "model.sourceNotFound",
+    });
+  });
+
+  it("throws ToolError model.includeNotFound naming the include, not the entry point", async () => {
+    const load = vi.fn().mockRejectedValue(
+      new IncludeNotFoundError(
+        {
+          missingPath: "/abs/partials/missing.puml",
+          target: "partials/missing.puml",
+          includedFrom: "/abs/architecture.puml",
+          line: 3,
+          column: 1,
+        },
+        "PlantUML",
+      ),
+    );
+    mockLoadFormat.mockResolvedValue(fakeFormat(load));
+
+    const error = (await loadModel(plantumlConfig).catch(
+      (error_: unknown) => error_,
+    )) as ToolError;
+
+    expect(error).toMatchObject({
+      name: "ToolError",
+      kind: "model.includeNotFound",
+      context: {
+        path: "/abs/partials/missing.puml",
+        includedFrom: "/abs/architecture.puml",
+        line: "3",
+        column: "1",
+      },
+    });
+    expect(error.message).toContain("/abs/partials/missing.puml");
+    expect(error.message).toContain("/abs/architecture.puml:3:1");
+  });
+
+  it("attributes a bare ENOENT to the errno path when it isn't the entry point", async () => {
+    // Loaders that pull extra files in without wrapping their own ENOENT
+    // (Structurizr `!include <dir>`, Compose `include:`) still must not
+    // send the reader to source.path.
+    const err = enoent();
+    err.path = "/abs/parts/missing.dsl";
+    const load = vi.fn().mockRejectedValue(err);
+    mockLoadFormat.mockResolvedValue(fakeFormat(load));
+
+    await expect(loadModel(structurizrConfig)).rejects.toMatchObject({
+      name: "ToolError",
+      kind: "model.includeNotFound",
+      message: expect.stringContaining("/abs/parts/missing.dsl"),
+    });
+  });
+
+  it("keeps model.sourceNotFound when the errno path is the entry point itself", async () => {
+    const err = enoent();
+    err.path = path.resolve("./architecture.puml");
+    const load = vi.fn().mockRejectedValue(err);
+    mockLoadFormat.mockResolvedValue(fakeFormat(load));
+
+    await expect(loadModel(plantumlConfig)).rejects.toMatchObject({
+      name: "ToolError",
+      kind: "model.sourceNotFound",
+      message: expect.stringContaining("./architecture.puml"),
     });
   });
 

--- a/test/cli/output/flush.test.ts
+++ b/test/cli/output/flush.test.ts
@@ -1,0 +1,86 @@
+import { flushOutput } from "../../../src/cli/output/flush";
+
+/**
+ * The barrier that keeps `aact <cmd> --json | consumer` from losing its
+ * tail: `process.exit` discards whatever stdout still has buffered, so
+ * the exit path waits for the buffer to reach the OS first.
+ */
+
+interface FakeStream {
+  writableLength?: number;
+  write: ReturnType<typeof vi.fn>;
+}
+
+const fakeStream = (writableLength?: number): FakeStream => ({
+  ...(writableLength === undefined ? {} : { writableLength }),
+  write: vi.fn((_chunk: string, cb?: () => void) => {
+    cb?.();
+    return true;
+  }),
+});
+
+const useStreams = (stdout: unknown, stderr?: unknown): void => {
+  vi.spyOn(process, "stdout", "get").mockReturnValue(
+    stdout as NodeJS.WriteStream & { fd: 1 },
+  );
+  vi.spyOn(process, "stderr", "get").mockReturnValue(
+    stderr as NodeJS.WriteStream & { fd: 2 },
+  );
+};
+
+describe("flushOutput", () => {
+  it("skips the barrier write when nothing is buffered", async () => {
+    const stdout = fakeStream(0);
+    const stderr = fakeStream(0);
+    useStreams(stdout, stderr);
+
+    await flushOutput();
+
+    expect(stdout.write).not.toHaveBeenCalled();
+    expect(stderr.write).not.toHaveBeenCalled();
+  });
+
+  it("waits for the buffered tail of both streams", async () => {
+    const stdout = fakeStream(70_000);
+    const stderr = fakeStream(12);
+    useStreams(stdout, stderr);
+
+    await flushOutput();
+
+    expect(stdout.write).toHaveBeenCalledWith("", expect.any(Function));
+    expect(stderr.write).toHaveBeenCalledWith("", expect.any(Function));
+  });
+
+  it("resolves only after the write callback fires", async () => {
+    let release: (() => void) | undefined;
+    const stdout: FakeStream = {
+      writableLength: 70_000,
+      write: vi.fn((_chunk: string, cb: () => void) => {
+        release = cb;
+        return false;
+      }),
+    };
+    useStreams(stdout, fakeStream(0));
+
+    let settled = false;
+    const pending = flushOutput().then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    release?.();
+    await pending;
+    expect(settled).toBe(true);
+  });
+
+  it("tolerates streams that aren't real Writables", async () => {
+    // Tests (and odd hosts) substitute plain objects for the standard
+    // streams; a missing `write` / `writableLength` must not hang the
+    // exit path.
+    useStreams({});
+
+    await expect(flushOutput()).resolves.toBeUndefined();
+  });
+});

--- a/test/cli/skill.test.ts
+++ b/test/cli/skill.test.ts
@@ -19,7 +19,7 @@ import type { CliEnvelope } from "../../src/cli/output";
 // We only shell out to a local throwaway git repo (no network) in these tests.
 const { execFileSync } = await import("node:child_process");
 
-const defaultRepo = "https://github.com/Byndyusoft/aact-architect-skill.git";
+const defaultRepo = "https://github.com/ChS23/aact-architect-skill.git";
 const fixedDate = new Date("2026-05-16T00:00:00.000Z");
 
 interface GitCall {

--- a/test/e2e/cli.test.ts
+++ b/test/e2e/cli.test.ts
@@ -328,6 +328,35 @@ describe("aact model", () => {
     expect(model).toHaveProperty("rootBoundaryNames");
   });
 
+  it("--json survives a pipe larger than the 64 KB pipe buffer", async () => {
+    // Regression: `process.exit` right after an async write dropped
+    // everything stdout still had buffered, so a piped consumer got the
+    // envelope cut at exactly 65536 bytes — invalid JSON. Only a real
+    // subprocess with a piped stdout reproduces it; a TTY or a file
+    // redirect writes synchronously and hides the bug.
+    const containers = Array.from(
+      { length: 300 },
+      (_, i) =>
+        `  Container(svc${i}, "Service ${i}", "Node.js", "Does thing ${i} with a description long enough to inflate the payload")`,
+    ).join("\n");
+    const relations = Array.from(
+      { length: 299 },
+      (_, i) => `Rel(svc${i}, svc${i + 1}, "calls ${i}", "HTTP/JSON")`,
+    ).join("\n");
+    await fs.writeFile(
+      path.join(workDir, "big.puml"),
+      `@startuml\nSystem_Boundary(sb, "Shop") {\n${containers}\n}\n${relations}\n@enduml\n`,
+    );
+
+    const result = await runCli(["model", "big.puml", "--json"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.length).toBeGreaterThan(65_536);
+    const envelope = JSON.parse(result.stdout) as Record<string, unknown>;
+    const data = envelope.data as { model: { elements: object } };
+    expect(Object.keys(data.model.elements)).toHaveLength(300);
+  });
+
   it("--json exits 2 on missing source file (model command never crashes)", async () => {
     await runCli(["init"]);
     await fs.rm(path.join(workDir, "architecture.puml"));

--- a/test/e2e/cli.test.ts
+++ b/test/e2e/cli.test.ts
@@ -357,6 +357,29 @@ describe("aact model", () => {
     expect(Object.keys(data.model.elements)).toHaveLength(300);
   });
 
+  it("--json names the missing !include, not the entry point", async () => {
+    await fs.writeFile(
+      path.join(workDir, "main.puml"),
+      `@startuml\n!include partials/missing.puml\nContainer(api, "API")\n@enduml\n`,
+    );
+
+    const result = await runCli(["model", "main.puml", "--json"]);
+
+    expect(result.exitCode).toBe(2);
+    const envelope = JSON.parse(result.stdout) as {
+      diagnostics: {
+        kind: string;
+        message: string;
+        context: Record<string, string>;
+      }[];
+    };
+    const diagnostic = envelope.diagnostics[0];
+    expect(diagnostic.kind).toBe("model.includeNotFound");
+    expect(diagnostic.message).toContain("partials/missing.puml");
+    expect(diagnostic.context.includedFrom).toContain("main.puml");
+    expect(diagnostic.context.line).toBe("2");
+  });
+
   it("--json exits 2 on missing source file (model command never crashes)", async () => {
     await runCli(["init"]);
     await fs.rm(path.join(workDir, "architecture.puml"));

--- a/test/formats/plantuml/load.test.ts
+++ b/test/formats/plantuml/load.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 
 import path from "pathe";
 
+import { IncludeNotFoundError } from "../../../src/formats/_shared/includeError";
 import { load } from "../../../src/formats/plantuml/load";
 import { plantumlSyntax } from "../../../src/formats/plantuml/syntax";
 import type { Model } from "../../../src/model";
@@ -99,6 +100,49 @@ describe("PlantUML load — unit", () => {
     expect(result.issues).not.toContainEqual(
       expect.objectContaining({ message: expect.stringMatching(/include/i) }),
     );
+  });
+
+  it("names the missing include, not the file that referenced it", async () => {
+    // Regression: a missing !include used to surface as a bare ENOENT,
+    // which the CLI collapsed into "Architecture file not found:
+    // <entry point>" — pointing at the one file that does exist.
+    const file = await writeFixture(
+      "main-missing-include.puml",
+      [
+        "@startuml",
+        "  !include partials/missing.puml",
+        'Container(api, "API")',
+        "@enduml",
+      ].join("\n"),
+    );
+
+    const error = await load(file).catch((error_: unknown) => error_);
+
+    expect(error).toBeInstanceOf(IncludeNotFoundError);
+    expect((error as IncludeNotFoundError).site).toEqual({
+      missingPath: path.join(tmpDir, "partials", "missing.puml"),
+      target: "partials/missing.puml",
+      includedFrom: file,
+      line: 2,
+      column: 3,
+    });
+  });
+
+  it("reports the innermost missing include of a nested chain", async () => {
+    await writeFixture("level1.puml", "!include level2.puml\n");
+    const file = await writeFixture(
+      "main-nested-include.puml",
+      ["@startuml", "!include level1.puml", "@enduml"].join("\n"),
+    );
+
+    const error = await load(file).catch((error_: unknown) => error_);
+
+    expect(error).toBeInstanceOf(IncludeNotFoundError);
+    expect((error as IncludeNotFoundError).site).toMatchObject({
+      missingPath: path.join(tmpDir, "level2.puml"),
+      includedFrom: path.join(tmpDir, "level1.puml"),
+      line: 1,
+    });
   });
 
   it("expands local !include_once only once", async () => {

--- a/test/formats/structurizr/load.dsl.test.ts
+++ b/test/formats/structurizr/load.dsl.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 
 import path from "pathe";
 
+import { IncludeNotFoundError } from "../../../src/formats/_shared/includeError";
 import { load } from "../../../src/formats/structurizr/load";
 
 const ECOMMERCE_DSL = path.resolve(
@@ -204,6 +205,30 @@ describe("structurizrFormat.load — .dsl edge cases", () => {
     );
 
     await expect(load(main)).rejects.toThrow(/include cycle detected/);
+  });
+
+  it("names the missing !include target, not the workspace that references it", async () => {
+    // Regression: the ENOENT of an include used to reach the CLI
+    // indistinguishable from a missing entry point, so the diagnostic
+    // blamed workspace.dsl — a file that is right there.
+    const dir = await mkdtemp(path.join(tmpdir(), "aact-struct-missing-inc-"));
+    const main = path.join(dir, "workspace.dsl");
+    await writeFile(
+      main,
+      `workspace {\n  model {\n    !include parts/missing.dsl\n  }\n}\n`,
+      "utf8",
+    );
+
+    const error = await load(main).catch((error_: unknown) => error_);
+
+    expect(error).toBeInstanceOf(IncludeNotFoundError);
+    expect((error as IncludeNotFoundError).site).toEqual({
+      missingPath: path.join(dir, "parts", "missing.dsl"),
+      target: "parts/missing.dsl",
+      includedFrom: main,
+      line: 3,
+      column: 5,
+    });
   });
 
   it("throws a truncated, readable summary when a .dsl has many parse errors", async () => {


### PR DESCRIPTION
Патч-релиз поверх текущего main. Три бага нашлись на прогоне корпуса из 159 реальных Structurizr-воркспейсов, два — при проверке путей установки после GA.

- **`--json` обрезался ровно на 65536 байт, когда stdout — pipe.** `process.exit` вызывался сразу после асинхронной записи, хвост терялся. Любой агент, читающий envelope через subprocess, получал невалидный JSON — модели от ~40 элементов уже за порогом. Теперь exit ждёт, пока оба стандартных потока дойдут до ОС. Через файл и в TTY всё писалось целиком, поэтому баг дожил до GA.
- **Пропавший `!include` назывался «Architecture file not found: <главный файл>»** — то есть файл, который на месте. Новый диагностик `model.includeNotFound` с путём пропавшего файла, файлом-родителем, строкой и колонкой; во вложенных цепочках называется самый глубокий. Работает и для C4-PlantUML, и для Structurizr DSL.
- **`aact skill install` клонировал `Byndyusoft/aact-architect-skill`, которого пока нет** (404) — документированный способ поставить скилл падал. Вернул на `ChS23/aact-architect-skill`; как перенесёшь репозиторий в организацию, переключим обратно одной строкой.
- **`aact view` предлагал ставить `aact@beta` / `@aact/view@beta`** после выхода стабильной.
- `chore: release v3.0.1` — bump обоих пакетов + CHANGELOG.

В CHANGELOG отдельным пунктом отмечено, что `FormatSyntax.containerDecl(element)` — breaking для кастомных правил, и что он выходит в патче, потому что приехал вместе с ревью-фиксами.

Проверки: unit 1999 / integration 56 / e2e 48, coverage 95.4 / 87.8 / 96.0 / 96.5, publint чист. Оба пакета уже в npm: `aact@3.0.1` и `@aact/view@3.0.1` (у companion это первая стабильная — на 3.0.0 он не публиковался, `latest` висел на beta.19).
